### PR TITLE
chore: Remove utils.js from basic-auth examples

### DIFF
--- a/examples/api-basic-auth-middleware/basic-auth.w
+++ b/examples/api-basic-auth-middleware/basic-auth.w
@@ -1,9 +1,5 @@
 bring cloud;
-
-pub class Utils {
-  extern "./utils.js" pub static inflight base64decode(value: str): str;
-  extern "./utils.js" pub static inflight base64encode(value: str): str;
-}
+bring util;
 
 pub struct Credentials {
   username: str;
@@ -33,7 +29,7 @@ pub class BasicAuth {
   }
 
   inflight authCredentials(header: str): Credentials {
-    let auth = Utils.base64decode(header.split(" ").at(1));
+    let auth = util.base64Decode(header.split(" ").at(1));
     let splittedAuth = auth.split(":");
     let username = splittedAuth.at(0);
     let password = splittedAuth.at(1);

--- a/examples/api-basic-auth-middleware/main.w
+++ b/examples/api-basic-auth-middleware/main.w
@@ -1,5 +1,6 @@
 bring cloud;
 bring http;
+bring util;
 bring "./basic-auth.w" as auth;
 bring expect;
 
@@ -54,7 +55,7 @@ test "authenticated" {
   let response = http.get("${apiUrl}/hello-middleware", {
     headers: {
       Accept: "application/json",
-      Authorization: "Basic " + auth.Utils.base64encode("admin:admin")
+      Authorization: "Basic " + util.base64Encode("admin:admin")
     }
   });
   expect.equal(response.status, 200);  

--- a/examples/api-basic-auth-middleware/utils.js
+++ b/examples/api-basic-auth-middleware/utils.js
@@ -1,7 +1,0 @@
-export function base64decode(str) {
-  return Buffer.from(str, 'base64').toString('utf8');
-}
-
-export function base64encode(str) {
-  return Buffer.from(str, 'utf8').toString('base64');
-}

--- a/examples/api-basic-auth/utils.js
+++ b/examples/api-basic-auth/utils.js
@@ -1,7 +1,0 @@
-export function base64decode(str) {
-  return Buffer.from(str, 'base64').toString('utf8');
-}
-
-export function base64encode(str) {
-  return Buffer.from(str, 'utf8').toString('base64');
-}


### PR DESCRIPTION
Remove utils.js from basic-auth and api-basic-auth-middleware. Change calls in middleware to use util.