### PR TITLE
fix: update awscdk examples align with best practice

### DIFF
--- a/.github/workflows/wing-provider-specific.yml
+++ b/.github/workflows/wing-provider-specific.yml
@@ -46,10 +46,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name: Setup Node.js v18
+      - name: Setup Node.js v20
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: Install winglang globally
         run: |
           npm install -g winglang@latest

--- a/examples/provider-specific/awscdk-docker-python-lambda/Readme.md
+++ b/examples/provider-specific/awscdk-docker-python-lambda/Readme.md
@@ -4,32 +4,39 @@ This isn't leveraging the Wing SDK, but using Constructs from the AWS CDK direct
 
 This is largely based on an example by [Marcio Cruz](https://github.com/marciocadev) who contributed the AWS CDK provider for wing.
 
+This project is using the [AWS CDK target platform](https://www.winglang.io/docs/platforms/awscdk).
+
+![diagram](./diagram.png)
+
 ## Prerequisite
 
-Please make sure to use a current and working setup of the [wing cli](https://docs.winglang.io/getting-started/installation).
+Please make sure to use a current and working setup of the [Wing
+CLI](https://docs.winglang.io/getting-started/installation)
 
 ## Usage
 
 ### Setup
 
-Nb: In case of a globally installed Wing CLI, the `aws-cdk-lib` package needs to be installed globally as well. See this [issue](https://github.com/winglang/wing/issues/2478) for more details.
-
-```
+```sh
 npm install
 ```
 
-### Wing Console
+### Wing Simulator
 
-As of May 2023 the Wing Console is not yet supported.
+```sh
+wing it
+```
 
-### Wing Tests
+### Bootstrap
 
-As of May 2023 tests are not yet supported out of the box
+Before the first deployment to an AWS environment (account/region), you'll need to bootstrap some CDK resources:
+
+```sh
+npx cdk bootstrap
+```
 
 ### Deploy
 
-```
-export CDK_STACK_NAME="wing-docker-python-lambda"
-wing compile -t awscdk main.w
-npx cdk deploy --app "./target/main.awscdk"
+```sh
+npx cdk deploy
 ```

--- a/examples/provider-specific/awscdk-docker-python-lambda/cdk.json
+++ b/examples/provider-specific/awscdk-docker-python-lambda/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "CDK_STACK_NAME=awscdk-docker-python-lambda-test wing compile --no-analytics --no-update-check --platform @winglang/platform-awscdk main.w",
+  "output": "target/main.awscdk"
+}

--- a/examples/provider-specific/awscdk-docker-python-lambda/package-lock.json
+++ b/examples/provider-specific/awscdk-docker-python-lambda/package-lock.json
@@ -5,9 +5,9 @@
   "packages": {
     "": {
       "dependencies": {
-        "@winglang/platform-awscdk": "^0.59.22",
-        "aws-cdk": "^2.130.0",
-        "aws-cdk-lib": "^2.130.0"
+        "@winglang/platform-awscdk": "^0.71.3",
+        "aws-cdk": "^2.138.0",
+        "aws-cdk-lib": "^2.138.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -21,9 +21,9 @@
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
+      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",
@@ -371,20 +371,20 @@
       }
     },
     "node_modules/@winglang/platform-awscdk": {
-      "version": "0.59.22",
-      "resolved": "https://registry.npmjs.org/@winglang/platform-awscdk/-/platform-awscdk-0.59.22.tgz",
-      "integrity": "sha512-Ed5EulXkZqEmfFGUD2f8lErDeC+j0IhB+l1bRHusyUkpRwCsiXA85WOEHFls7ljU3+WVFSVLt7zUS2wtXZ4mqA==",
+      "version": "0.71.3",
+      "resolved": "https://registry.npmjs.org/@winglang/platform-awscdk/-/platform-awscdk-0.71.3.tgz",
+      "integrity": "sha512-4JvijpSkIuR1+eIA7IYkrl5jPjv9TvN4OOzMDTrvjyrygkM2wAXZ/XyJPzKxptYYTelgomT/WPO4hKO2Ger7ww==",
       "dependencies": {
-        "@winglang/sdk": "0.59.22",
+        "@winglang/sdk": "0.71.3",
         "aws-cdk-lib": "^2.124.0",
         "constructs": "^10.3",
         "safe-stable-stringify": "^2.4.3"
       }
     },
     "node_modules/@winglang/sdk": {
-      "version": "0.59.22",
-      "resolved": "https://registry.npmjs.org/@winglang/sdk/-/sdk-0.59.22.tgz",
-      "integrity": "sha512-L6ci8py0gN/UoWpNbGtH5htxr6iZN3GrRAVBAy5xOhh68fpdwyUE9sXXHyDhRGJORVd+g2NBTG2YynymAbisew==",
+      "version": "0.71.3",
+      "resolved": "https://registry.npmjs.org/@winglang/sdk/-/sdk-0.71.3.tgz",
+      "integrity": "sha512-lM9WDadsW80CmFycKTIFYSc94yuKUrE2qSaeBLEhzkDPWJxwmzEQZ/U7gbjj9S9tcixpgwW0FhfAXNKIk1Ihpg==",
       "bundleDependencies": [
         "@aws-sdk/client-cloudwatch-logs",
         "@aws-sdk/client-dynamodb",
@@ -406,13 +406,16 @@
         "@smithy/util-stream",
         "@smithy/util-utf8",
         "@types/aws-lambda",
+        "@winglang/wingtunnels",
         "ajv",
         "cdktf",
         "cron-parser",
+        "cron-validator",
         "express",
+        "glob",
         "google-auth-library",
         "ioredis",
-        "jsonschema",
+        "jiti",
         "mime",
         "mime-types",
         "nanoid",
@@ -421,8 +424,8 @@
         "stacktracey",
         "toml",
         "ulid",
-        "undici",
         "uuid",
+        "vlq",
         "yaml"
       ],
       "dependencies": {
@@ -446,14 +449,17 @@
         "@smithy/util-stream": "2.0.17",
         "@smithy/util-utf8": "2.0.0",
         "@types/aws-lambda": "^8.10.119",
+        "@winglang/wingtunnels": "0.71.3",
         "ajv": "^8.12.0",
         "cdktf": "0.20.3",
         "constructs": "^10.3",
         "cron-parser": "^4.9.0",
-        "express": "^4.18.2",
+        "cron-validator": "^1.3.1",
+        "express": "^4.19.2",
+        "glob": "^8.1.0",
         "google-auth-library": "^8.9.0",
         "ioredis": "^5.3.2",
-        "jsonschema": "^1.4.1",
+        "jiti": "^1.21.0",
         "mime": "^3.0.0",
         "mime-types": "^2.1.35",
         "nanoid": "^3.3.6",
@@ -462,8 +468,8 @@
         "stacktracey": "^2.1.8",
         "toml": "^3.0.0",
         "ulid": "^2.3.0",
-        "undici": "^6.6.2",
         "uuid": "^8.3.2",
+        "vlq": "^2.0.4",
         "yaml": "^2.3.2"
       },
       "engines": {
@@ -1895,14 +1901,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@winglang/sdk/node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@winglang/sdk/node_modules/@google-cloud/datastore": {
       "version": "8.4.0",
       "inBundle": true,
@@ -2724,6 +2722,11 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@winglang/sdk/node_modules/@types/ms": {
+      "version": "0.7.34",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@winglang/sdk/node_modules/@types/node": {
       "version": "20.11.0",
       "inBundle": true,
@@ -2763,6 +2766,533 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels": {
+      "version": "0.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.9",
+        "@types/node": "^20.11.19",
+        "@types/ws": "^8.5.7",
+        "debug": "^4.3.4",
+        "ws": "^8.14.2"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/@types/debug": {
+      "version": "4.1.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/@types/node": {
+      "version": "20.11.20",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/@types/ws": {
+      "version": "8.5.10",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack": {
+      "version": "0.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "dependencies": {
+        "@actions/core": "^1.10.1",
+        "@pnpm/find-workspace-dir": "^6.0.2",
+        "@pnpm/reviewing.dependencies-hierarchy": "^2.0.10",
+        "@pnpm/workspace.find-packages": "^1.0.5",
+        "changelogen": "^0.5.5",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "npm-which": "^3.0.1",
+        "semver": "^7.5.4",
+        "tsx": "^4.7.0"
+      },
+      "bin": {
+        "bump-pack": "bin/bump-pack.cjs",
+        "link-bundles": "bin/link-bundles.cjs",
+        "turbo-diff": "bin/turbo-diff.cjs"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@actions/core": {
+      "version": "1.10.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@pnpm/find-workspace-dir": {
+      "version": "6.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/error": "5.0.2",
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@pnpm/reviewing.dependencies-hierarchy": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/dependency-path": "2.1.4",
+        "@pnpm/lockfile-file": "8.1.3",
+        "@pnpm/lockfile-utils": "8.0.6",
+        "@pnpm/matcher": "5.0.0",
+        "@pnpm/modules-yaml": "12.1.3",
+        "@pnpm/normalize-registries": "5.0.3",
+        "@pnpm/npm-package-arg": "^1.0.0",
+        "@pnpm/read-modules-dir": "6.0.1",
+        "@pnpm/read-package-json": "8.0.4",
+        "@pnpm/types": "9.3.0",
+        "normalize-path": "^3.0.0",
+        "realpath-missing": "^1.1.0",
+        "resolve-link-target": "^2.0.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@pnpm/workspace.find-packages": {
+      "version": "1.0.13",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/cli-utils": "2.0.23",
+        "@pnpm/constants": "7.1.1",
+        "@pnpm/fs.find-packages": "2.0.7",
+        "@pnpm/types": "9.3.0",
+        "@pnpm/util.lex-comparator": "1.0.0",
+        "read-yaml-file": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      },
+      "peerDependencies": {
+        "@pnpm/logger": "^5.0.0"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@types/fs-extra": {
+      "version": "11.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@types/node": {
+      "version": "20.11.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@types/semver": {
+      "version": "7.5.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/changelogen": {
+      "version": "0.5.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "c12": "^1.4.2",
+        "colorette": "^2.0.20",
+        "consola": "^3.2.3",
+        "convert-gitmoji": "^0.1.3",
+        "execa": "^8.0.1",
+        "mri": "^1.2.0",
+        "node-fetch-native": "^1.2.0",
+        "ofetch": "^1.1.1",
+        "open": "^9.1.0",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "scule": "^1.0.0",
+        "semver": "^7.5.4",
+        "std-env": "^3.4.2",
+        "yaml": "^2.3.1"
+      },
+      "bin": {
+        "changelogen": "dist/cli.mjs"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/minimatch": {
+      "version": "9.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/npm-which": {
+      "version": "3.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
+      },
+      "bin": {
+        "npm-which": "bin/npm-which.js"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/semver": {
+      "version": "7.5.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/tsx": {
+      "version": "4.7.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/typescript": {
+      "version": "5.2.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/vitest": {
+      "version": "0.34.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^4.3.5",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "@vitest/expect": "0.34.6",
+        "@vitest/runner": "0.34.6",
+        "@vitest/snapshot": "0.34.6",
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "acorn": "^8.9.0",
+        "acorn-walk": "^8.2.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.1",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.3",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.7.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
+        "vite-node": "0.34.6",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "playwright": "*",
+        "safaridriver": "*",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/debug": {
+      "version": "4.3.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/tsup": {
+      "version": "6.7.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^4.0.0",
+        "cac": "^6.7.12",
+        "chokidar": "^3.5.1",
+        "debug": "^4.3.1",
+        "esbuild": "^0.17.6",
+        "execa": "^5.0.0",
+        "globby": "^11.0.3",
+        "joycon": "^3.0.1",
+        "postcss-load-config": "^3.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^3.2.5",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.20.3",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/typescript": {
+      "version": "5.3.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/vitest": {
+      "version": "0.34.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^4.3.5",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "@vitest/expect": "0.34.6",
+        "@vitest/runner": "0.34.6",
+        "@vitest/snapshot": "0.34.6",
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "acorn": "^8.9.0",
+        "acorn-walk": "^8.2.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.1",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.3",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.7.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
+        "vite-node": "0.34.6",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "playwright": "*",
+        "safaridriver": "*",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/ws": {
+      "version": "8.14.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@winglang/sdk/node_modules/abort-controller": {
@@ -2870,6 +3400,11 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@winglang/sdk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@winglang/sdk/node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -2898,12 +3433,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/body-parser": {
-      "version": "1.20.1",
+      "version": "1.20.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -2911,7 +3446,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -2924,6 +3459,14 @@
       "version": "2.11.0",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/@winglang/sdk/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/@winglang/sdk/node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -3580,7 +4123,7 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/cookie": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3602,6 +4145,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@winglang/sdk/node_modules/cron-validator": {
+      "version": "1.3.1",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@winglang/sdk/node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
@@ -3766,16 +4314,16 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/express": {
-      "version": "4.18.2",
+      "version": "4.19.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3888,6 +4436,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/@winglang/sdk/node_modules/function-bind": {
       "version": "1.1.2",
       "inBundle": true,
@@ -3951,6 +4504,24 @@
       "dependencies": {
         "data-uri-to-buffer": "^2.0.0",
         "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/glob": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@winglang/sdk/node_modules/google-auth-library": {
@@ -4111,6 +4682,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/@winglang/sdk/node_modules/inherits": {
       "version": "2.0.4",
       "inBundle": true,
@@ -4204,6 +4784,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/jiti": {
+      "version": "1.21.0",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/@winglang/sdk/node_modules/json-bigint": {
       "version": "1.0.0",
       "inBundle": true,
@@ -4216,14 +4804,6 @@
       "version": "1.0.0",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@winglang/sdk/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/@winglang/sdk/node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -4388,6 +4968,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/minimatch": {
+      "version": "5.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@winglang/sdk/node_modules/mnemonist": {
@@ -4619,7 +5210,7 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/raw-body": {
-      "version": "2.5.1",
+      "version": "2.5.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4996,17 +5587,6 @@
         "ulid": "bin/cli.js"
       }
     },
-    "node_modules/@winglang/sdk/node_modules/undici": {
-      "version": "6.6.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
     "node_modules/@winglang/sdk/node_modules/undici-types": {
       "version": "5.26.5",
       "inBundle": true,
@@ -5056,6 +5636,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/@winglang/sdk/node_modules/vlq": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@winglang/sdk/node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -5170,9 +5755,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.130.0.tgz",
-      "integrity": "sha512-MsjGzQ2kZv0FEfXvpW7FTJRnefew0GrYt9M2SMN2Yn45+yjugGl2X8to416kABeFz1OFqW56hq8Y5BiLuFDVLQ==",
+      "version": "2.138.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.138.0.tgz",
+      "integrity": "sha512-48xvfEaiM07RB+p05RHqRAVtKcxkGzXnwdTo765Ba0rUFK2ZQ9leykVeBDvdCj9u0eMv2fCRspP/wQxPOU2H/g==",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -5184,9 +5769,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.130.0.tgz",
-      "integrity": "sha512-yK7ibePipdjlI4AFM94fwwtsCkmpWJ0JFZTMPahahC/3Pxe/BA/nnI/4Namvl5QPxW5QlU0xQYU7cywioq3RQg==",
+      "version": "2.138.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.138.0.tgz",
+      "integrity": "sha512-BdLOd6Fkl/7PH8RahRbhYQf3zRFCxVtOdkKOAZHHqtaNkmTyfkUGMXyzyQ4rIHvR8EOy1C1x5CAufqoZuJM0gA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -5203,7 +5788,7 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -5213,7 +5798,7 @@
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
         "semver": "^7.6.0",
-        "table": "^6.8.1",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -5501,7 +6086,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/examples/provider-specific/awscdk-docker-python-lambda/package.json
+++ b/examples/provider-specific/awscdk-docker-python-lambda/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@winglang/platform-awscdk": "^0.59.22",
-    "aws-cdk": "^2.130.0",
-    "aws-cdk-lib": "^2.130.0"
+    "@winglang/platform-awscdk": "^0.71.3",
+    "aws-cdk": "^2.138.0",
+    "aws-cdk-lib": "^2.138.0"
   }
 }

--- a/examples/provider-specific/awscdk-docker-python-lambda/test.sh
+++ b/examples/provider-specific/awscdk-docker-python-lambda/test.sh
@@ -6,13 +6,10 @@ trap 'catch_error' ERR
 
 function catch_error() {
     echo "Error occurred. Running 'npx cdk destroy'..."
-    npx cdk destroy --force --app "./target/main.awscdk"
+    npx cdk destroy --force
 }
 
-export CDK_STACK_NAME="awscdk-docker-python-lambda-test"
-# aws-cdk-lib is required for the AWS CDK examples, there's an issue about it https://github.com/winglang/wing/issues/2478
 npm install
 VERSION=$(npm list aws-cdk | grep aws-cdk@ | cut -d'@' -f2); npm install -g "aws-cdk-lib@$VERSION"
-wing compile --no-analytics --no-update-check --platform @winglang/platform-awscdk main.w
-npx cdk deploy --require-approval never --outputs-file outputs.json --app "./target/main.awscdk"
-npx cdk destroy --force --app "./target/main.awscdk"
+npx cdk deploy --require-approval never --outputs-file outputs.json
+npx cdk destroy --force

--- a/examples/provider-specific/awscdk-hello-wing/Readme.md
+++ b/examples/provider-specific/awscdk-hello-wing/Readme.md
@@ -2,38 +2,43 @@
 
 The example from the [getting started](https://www.winglang.io/docs/start-here/hello) guide.
 
-This is a simple example of a WingLang project that demonstrates the usage of cloud services. The program creates a cloud bucket and a cloud queue. It then adds a consumer to the queue, which writes a message to a file in the bucket.
+This is a simple example of a Wing project that demonstrates the usage of cloud services. The
+program creates a cloud bucket and a cloud queue. It then adds a consumer to the queue, which writes
+a message to a file in the bucket.
+
+This project is using the [AWS CDK target platform](https://www.winglang.io/docs/platforms/awscdk).
 
 ![diagram](./diagram.png)
 
 ## Prerequisite
 
-Please make sure to use a current and working setup of the [wing cli](https://docs.winglang.io/getting-started/installation)
+Please make sure to use a current and working setup of the [Wing
+CLI](https://docs.winglang.io/getting-started/installation)
 
 ## Usage
 
 ### Setup
 
-Nb: In case of a globally installed Wing CLI, the `aws-cdk-lib` package needs to be installed globally as well. See this [issue](https://github.com/winglang/wing/issues/2478) for more details.
-
-```
+```sh
 npm install
 ```
 
-### Wing Console
+### Wing Simulator
 
-```
+```sh
 wing it
 ```
 
-### Wing Tests
+### Bootstrap
 
-As of May 2023 tests are currently not yet supported out of the box
+Before the first deployment to an AWS environment (account/region), you'll need to bootstrap some CDK resources:
+
+```sh
+npx cdk bootstrap
+```
 
 ### Deploy
 
-```
-export CDK_STACK_NAME="hello-wing"
-wing compile -t awscdk main.w
-npx cdk deploy --app "./target/main.awscdk"
+```sh
+npx cdk deploy
 ```

--- a/examples/provider-specific/awscdk-hello-wing/cdk.json
+++ b/examples/provider-specific/awscdk-hello-wing/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "CDK_STACK_NAME=hello-wing-test wing compile --no-analytics --no-update-check --platform @winglang/platform-awscdk main.w",
+  "output": "target/main.awscdk"
+}

--- a/examples/provider-specific/awscdk-hello-wing/package-lock.json
+++ b/examples/provider-specific/awscdk-hello-wing/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@winglang/platform-awscdk": "^0.59.22",
-        "aws-cdk": "^2.130.0"
+        "@winglang/platform-awscdk": "^0.71.3",
+        "aws-cdk": "^2.138.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
@@ -370,20 +370,20 @@
       }
     },
     "node_modules/@winglang/platform-awscdk": {
-      "version": "0.59.22",
-      "resolved": "https://registry.npmjs.org/@winglang/platform-awscdk/-/platform-awscdk-0.59.22.tgz",
-      "integrity": "sha512-Ed5EulXkZqEmfFGUD2f8lErDeC+j0IhB+l1bRHusyUkpRwCsiXA85WOEHFls7ljU3+WVFSVLt7zUS2wtXZ4mqA==",
+      "version": "0.71.3",
+      "resolved": "https://registry.npmjs.org/@winglang/platform-awscdk/-/platform-awscdk-0.71.3.tgz",
+      "integrity": "sha512-4JvijpSkIuR1+eIA7IYkrl5jPjv9TvN4OOzMDTrvjyrygkM2wAXZ/XyJPzKxptYYTelgomT/WPO4hKO2Ger7ww==",
       "dependencies": {
-        "@winglang/sdk": "0.59.22",
+        "@winglang/sdk": "0.71.3",
         "aws-cdk-lib": "^2.124.0",
         "constructs": "^10.3",
         "safe-stable-stringify": "^2.4.3"
       }
     },
     "node_modules/@winglang/sdk": {
-      "version": "0.59.22",
-      "resolved": "https://registry.npmjs.org/@winglang/sdk/-/sdk-0.59.22.tgz",
-      "integrity": "sha512-L6ci8py0gN/UoWpNbGtH5htxr6iZN3GrRAVBAy5xOhh68fpdwyUE9sXXHyDhRGJORVd+g2NBTG2YynymAbisew==",
+      "version": "0.71.3",
+      "resolved": "https://registry.npmjs.org/@winglang/sdk/-/sdk-0.71.3.tgz",
+      "integrity": "sha512-lM9WDadsW80CmFycKTIFYSc94yuKUrE2qSaeBLEhzkDPWJxwmzEQZ/U7gbjj9S9tcixpgwW0FhfAXNKIk1Ihpg==",
       "bundleDependencies": [
         "@aws-sdk/client-cloudwatch-logs",
         "@aws-sdk/client-dynamodb",
@@ -405,13 +405,16 @@
         "@smithy/util-stream",
         "@smithy/util-utf8",
         "@types/aws-lambda",
+        "@winglang/wingtunnels",
         "ajv",
         "cdktf",
         "cron-parser",
+        "cron-validator",
         "express",
+        "glob",
         "google-auth-library",
         "ioredis",
-        "jsonschema",
+        "jiti",
         "mime",
         "mime-types",
         "nanoid",
@@ -420,8 +423,8 @@
         "stacktracey",
         "toml",
         "ulid",
-        "undici",
         "uuid",
+        "vlq",
         "yaml"
       ],
       "dependencies": {
@@ -445,14 +448,17 @@
         "@smithy/util-stream": "2.0.17",
         "@smithy/util-utf8": "2.0.0",
         "@types/aws-lambda": "^8.10.119",
+        "@winglang/wingtunnels": "0.71.3",
         "ajv": "^8.12.0",
         "cdktf": "0.20.3",
         "constructs": "^10.3",
         "cron-parser": "^4.9.0",
-        "express": "^4.18.2",
+        "cron-validator": "^1.3.1",
+        "express": "^4.19.2",
+        "glob": "^8.1.0",
         "google-auth-library": "^8.9.0",
         "ioredis": "^5.3.2",
-        "jsonschema": "^1.4.1",
+        "jiti": "^1.21.0",
         "mime": "^3.0.0",
         "mime-types": "^2.1.35",
         "nanoid": "^3.3.6",
@@ -461,8 +467,8 @@
         "stacktracey": "^2.1.8",
         "toml": "^3.0.0",
         "ulid": "^2.3.0",
-        "undici": "^6.6.2",
         "uuid": "^8.3.2",
+        "vlq": "^2.0.4",
         "yaml": "^2.3.2"
       },
       "engines": {
@@ -1894,14 +1900,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@winglang/sdk/node_modules/@fastify/busboy": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@winglang/sdk/node_modules/@google-cloud/datastore": {
       "version": "8.4.0",
       "inBundle": true,
@@ -2723,6 +2721,11 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@winglang/sdk/node_modules/@types/ms": {
+      "version": "0.7.34",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@winglang/sdk/node_modules/@types/node": {
       "version": "20.11.0",
       "inBundle": true,
@@ -2762,6 +2765,533 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels": {
+      "version": "0.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.9",
+        "@types/node": "^20.11.19",
+        "@types/ws": "^8.5.7",
+        "debug": "^4.3.4",
+        "ws": "^8.14.2"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/@types/debug": {
+      "version": "4.1.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/@types/node": {
+      "version": "20.11.20",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/@types/ws": {
+      "version": "8.5.10",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack": {
+      "version": "0.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "dependencies": {
+        "@actions/core": "^1.10.1",
+        "@pnpm/find-workspace-dir": "^6.0.2",
+        "@pnpm/reviewing.dependencies-hierarchy": "^2.0.10",
+        "@pnpm/workspace.find-packages": "^1.0.5",
+        "changelogen": "^0.5.5",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "npm-which": "^3.0.1",
+        "semver": "^7.5.4",
+        "tsx": "^4.7.0"
+      },
+      "bin": {
+        "bump-pack": "bin/bump-pack.cjs",
+        "link-bundles": "bin/link-bundles.cjs",
+        "turbo-diff": "bin/turbo-diff.cjs"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@actions/core": {
+      "version": "1.10.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@pnpm/find-workspace-dir": {
+      "version": "6.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/error": "5.0.2",
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@pnpm/reviewing.dependencies-hierarchy": {
+      "version": "2.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/dependency-path": "2.1.4",
+        "@pnpm/lockfile-file": "8.1.3",
+        "@pnpm/lockfile-utils": "8.0.6",
+        "@pnpm/matcher": "5.0.0",
+        "@pnpm/modules-yaml": "12.1.3",
+        "@pnpm/normalize-registries": "5.0.3",
+        "@pnpm/npm-package-arg": "^1.0.0",
+        "@pnpm/read-modules-dir": "6.0.1",
+        "@pnpm/read-package-json": "8.0.4",
+        "@pnpm/types": "9.3.0",
+        "normalize-path": "^3.0.0",
+        "realpath-missing": "^1.1.0",
+        "resolve-link-target": "^2.0.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@pnpm/workspace.find-packages": {
+      "version": "1.0.13",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/cli-utils": "2.0.23",
+        "@pnpm/constants": "7.1.1",
+        "@pnpm/fs.find-packages": "2.0.7",
+        "@pnpm/types": "9.3.0",
+        "@pnpm/util.lex-comparator": "1.0.0",
+        "read-yaml-file": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      },
+      "peerDependencies": {
+        "@pnpm/logger": "^5.0.0"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@types/fs-extra": {
+      "version": "11.0.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@types/node": {
+      "version": "20.11.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/@types/semver": {
+      "version": "7.5.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/changelogen": {
+      "version": "0.5.5",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "c12": "^1.4.2",
+        "colorette": "^2.0.20",
+        "consola": "^3.2.3",
+        "convert-gitmoji": "^0.1.3",
+        "execa": "^8.0.1",
+        "mri": "^1.2.0",
+        "node-fetch-native": "^1.2.0",
+        "ofetch": "^1.1.1",
+        "open": "^9.1.0",
+        "pathe": "^1.1.1",
+        "pkg-types": "^1.0.3",
+        "scule": "^1.0.0",
+        "semver": "^7.5.4",
+        "std-env": "^3.4.2",
+        "yaml": "^2.3.1"
+      },
+      "bin": {
+        "changelogen": "dist/cli.mjs"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/minimatch": {
+      "version": "9.0.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/npm-which": {
+      "version": "3.0.1",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
+      },
+      "bin": {
+        "npm-which": "bin/npm-which.js"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/semver": {
+      "version": "7.5.4",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/tsx": {
+      "version": "4.7.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/typescript": {
+      "version": "5.2.2",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/bump-pack/node_modules/vitest": {
+      "version": "0.34.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^4.3.5",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "@vitest/expect": "0.34.6",
+        "@vitest/runner": "0.34.6",
+        "@vitest/snapshot": "0.34.6",
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "acorn": "^8.9.0",
+        "acorn-walk": "^8.2.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.1",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.3",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.7.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
+        "vite-node": "0.34.6",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "playwright": "*",
+        "safaridriver": "*",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/debug": {
+      "version": "4.3.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/tsup": {
+      "version": "6.7.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^4.0.0",
+        "cac": "^6.7.12",
+        "chokidar": "^3.5.1",
+        "debug": "^4.3.1",
+        "esbuild": "^0.17.6",
+        "execa": "^5.0.0",
+        "globby": "^11.0.3",
+        "joycon": "^3.0.1",
+        "postcss-load-config": "^3.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^3.2.5",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.20.3",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/typescript": {
+      "version": "5.3.3",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/vitest": {
+      "version": "0.34.6",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^4.3.5",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "@vitest/expect": "0.34.6",
+        "@vitest/runner": "0.34.6",
+        "@vitest/snapshot": "0.34.6",
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "acorn": "^8.9.0",
+        "acorn-walk": "^8.2.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.1",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.3",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.7.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
+        "vite-node": "0.34.6",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "playwright": "*",
+        "safaridriver": "*",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/@winglang/wingtunnels/node_modules/ws": {
+      "version": "8.14.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@winglang/sdk/node_modules/abort-controller": {
@@ -2869,6 +3399,11 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@winglang/sdk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/@winglang/sdk/node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -2897,12 +3432,12 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/body-parser": {
-      "version": "1.20.1",
+      "version": "1.20.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -2910,7 +3445,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -2923,6 +3458,14 @@
       "version": "2.11.0",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/@winglang/sdk/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
     },
     "node_modules/@winglang/sdk/node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -3579,7 +4122,7 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/cookie": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3601,6 +4144,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/@winglang/sdk/node_modules/cron-validator": {
+      "version": "1.3.1",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@winglang/sdk/node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
@@ -3765,16 +4313,16 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/express": {
-      "version": "4.18.2",
+      "version": "4.19.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3887,6 +4435,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/@winglang/sdk/node_modules/function-bind": {
       "version": "1.1.2",
       "inBundle": true,
@@ -3950,6 +4503,24 @@
       "dependencies": {
         "data-uri-to-buffer": "^2.0.0",
         "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/glob": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@winglang/sdk/node_modules/google-auth-library": {
@@ -4110,6 +4681,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/@winglang/sdk/node_modules/inherits": {
       "version": "2.0.4",
       "inBundle": true,
@@ -4203,6 +4783,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/@winglang/sdk/node_modules/jiti": {
+      "version": "1.21.0",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/@winglang/sdk/node_modules/json-bigint": {
       "version": "1.0.0",
       "inBundle": true,
@@ -4215,14 +4803,6 @@
       "version": "1.0.0",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@winglang/sdk/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/@winglang/sdk/node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -4387,6 +4967,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@winglang/sdk/node_modules/minimatch": {
+      "version": "5.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@winglang/sdk/node_modules/mnemonist": {
@@ -4618,7 +5209,7 @@
       }
     },
     "node_modules/@winglang/sdk/node_modules/raw-body": {
-      "version": "2.5.1",
+      "version": "2.5.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4995,17 +5586,6 @@
         "ulid": "bin/cli.js"
       }
     },
-    "node_modules/@winglang/sdk/node_modules/undici": {
-      "version": "6.6.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
     "node_modules/@winglang/sdk/node_modules/undici-types": {
       "version": "5.26.5",
       "inBundle": true,
@@ -5055,6 +5635,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/@winglang/sdk/node_modules/vlq": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/@winglang/sdk/node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -5169,9 +5754,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.130.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.130.0.tgz",
-      "integrity": "sha512-MsjGzQ2kZv0FEfXvpW7FTJRnefew0GrYt9M2SMN2Yn45+yjugGl2X8to416kABeFz1OFqW56hq8Y5BiLuFDVLQ==",
+      "version": "2.138.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.138.0.tgz",
+      "integrity": "sha512-48xvfEaiM07RB+p05RHqRAVtKcxkGzXnwdTo765Ba0rUFK2ZQ9leykVeBDvdCj9u0eMv2fCRspP/wQxPOU2H/g==",
       "bin": {
         "cdk": "bin/cdk"
       },

--- a/examples/provider-specific/awscdk-hello-wing/package.json
+++ b/examples/provider-specific/awscdk-hello-wing/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@winglang/platform-awscdk": "^0.59.22",
-    "aws-cdk": "^2.130.0"
+    "@winglang/platform-awscdk": "^0.71.3",
+    "aws-cdk": "^2.138.0"
   }
 }

--- a/examples/provider-specific/awscdk-hello-wing/test.sh
+++ b/examples/provider-specific/awscdk-hello-wing/test.sh
@@ -6,13 +6,10 @@ trap 'catch_error' ERR
 
 function catch_error() {
     echo "Error occurred. Running 'npx cdk destroy'..."
-    npx cdk destroy --force --app "./target/main.awscdk"
+    npx cdk destroy --force
 }
 
-export CDK_STACK_NAME="hello-wing-test"
-# aws-cdk-lib is required for the AWS CDK examples, there's an issue about it https://github.com/winglang/wing/issues/2478
 npm install
 VERSION=$(npm list aws-cdk | grep aws-cdk@ | cut -d'@' -f2); npm install -g "aws-cdk-lib@$VERSION"
-wing compile --no-analytics --no-update-check --platform @winglang/platform-awscdk main.w
-npx cdk deploy --require-approval never --outputs-file outputs.json --app "./target/main.awscdk"
-npx cdk destroy --force --app "./target/main.awscdk"
+npx cdk deploy --require-approval never --outputs-file outputs.json
+npx cdk destroy --force

--- a/examples/provider-specific/cdktf-terraform-hcl-module/test.sh
+++ b/examples/provider-specific/cdktf-terraform-hcl-module/test.sh
@@ -2,4 +2,4 @@
 
 set -xeuo pipefail
 npm install
-wing test --no-analytics --no-update-check --platform tf-aws main.w
+wing test --no-analytics --no-update-check --snapshots=deploy --platform tf-aws main.w


### PR DESCRIPTION
The *new* best practice as described in https://github.com/winglang/wing/pull/6286 is to configure a `cdk.json` file to use `wing compile` as the CDK app.

This standardizes the usage through the CDK CLI and enables all CDK features like context lookups, etc.